### PR TITLE
IOT_DS-8566: fix CLA trigger condition and enable CLA workflow triggers

### DIFF
--- a/.github/workflows/01-CLA-Assistant.yml
+++ b/.github/workflows/01-CLA-Assistant.yml
@@ -1,12 +1,9 @@
 name: 01-CLA-Assistant
-## This workflow is used for public repositories
-
 on:
-  workflow_dispatch:
- #issue_comment:
- #  types: [created]
- #pull_request_target:
- #  types: [opened,closed,synchronize,reopened]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize, reopened]
 
 permissions:
   actions: write
@@ -16,6 +13,12 @@ permissions:
 
 jobs:
   CLAAssistant:
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       (github.event.comment.body == 'recheck' ||
+        contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')))
     runs-on: ubuntu-24.04
     steps:
       - name: Create CLA Assistant Lite bot token
@@ -28,7 +31,6 @@ jobs:
           repositories: contributor-license-agreements
 
       - name: "CLA Assistant"
-        if: ${{ contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA') }} || github.event_name == 'pull_request_target'
         uses: SiliconLabsSoftware/action-cla-assistant@silabs_flavour_v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,7 +38,7 @@ jobs:
         with:
           path-to-signatures: "cla_signatures_db.json"
           path-to-document: "https://github.com/SiliconLabsSoftware/agreements-and-guidelines/blob/main/contributor_license_agreement.md"
-          branch: 'cla-database'
+          branch: "cla-database"
           allowlist: silabs-*,bot*
           # the following are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: "SiliconLabsInternal"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-### This is a template Dockerfile for the CI/CD pipeline
-
 FROM ubuntu:24.04
 
 ENV TZ=Europe/Budapest
@@ -13,9 +11,7 @@ ENV ARCH_BUILD_WRAPPER=$ARCH_BUILD_WRAPPER
 
 
 # Define the URLs for the tools
-##### TODO #####
 # Check and update version numbers if necessary
-
 ARG ARM_GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-${ARCH}-arm-none-eabi.tar.xz"
 ARG SIMPLICITY_COMMANDER_URL="https://www.silabs.com/documents/login/software/SimplicityCommander-Linux.zip"
 ARG SONAR_SCANNER_URL="https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-6.1.0.4477-linux-x64.zip"


### PR DESCRIPTION
This PR updates the CLA Assistant workflow trigger condition and enables trigger events for CLA processing.

Changes:
- Replace the CLA step condition with a guarded expression that handles `pull_request_target` and qualifying `issue_comment` events
- Enable `issue_comment` and `pull_request_target` triggers when they were commented out

Ticket: IOT_DS-8566

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to workflow triggering and conditions; main risk is unintended CLA runs/skips due to the updated event filter.
> 
> **Overview**
> Re-enables the `01-CLA-Assistant` workflow by turning on `issue_comment` and `pull_request_target` triggers.
> 
> Moves the CLA execution gating to a job-level `if` that runs on PR events, or on PR comments only when the comment is `recheck` or contains the CLA signing text (avoiding invalid context access on other comments). Also includes minor YAML/Dockerfile cleanup (quote/comment tweaks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6662a77b2ae5b67019ffbc63969384915ddc3c38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->